### PR TITLE
Add GitHub action to deploy mkdocs to GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - '**/README.md'
 
   workflow_dispatch:
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,22 @@
+name: Publish docs via GitHub Pages
+on:
+  push:
+    branches:
+      - master
+
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Deploy docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v3
+
+      - name: Deploy docs
+        uses: mhausenblas/mkdocs-deploy-gh-pages@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # EXTRA_PACKAGES: build-base
+          # REQUIREMENTS: folder/requirements.txt


### PR DESCRIPTION
This GitHub Action will automatically run on changes to the `master` branch (or manual trigger), and will generate and push the mkdocs wiki to Github Pages. A live example of what this would look like is here https://pfeerick.github.io/hdzero-wiki

Requires GitHub pages being enabled and configured in the repo settings, similar to as follows. 
![image](https://github.com/hdzerowiki/wiki/assets/5500713/47db0db0-4981-4f7d-9ded-72713cc13a89)

Also requires that the workflow actions token have permission to write to the repo (in order to update the `gh-pages` branch), (under Actions -> General).
![image](https://github.com/hdzerowiki/wiki/assets/5500713/b8da8a43-5a66-4c43-84d9-1850a37c0c50)
