### PR TITLE
Boilerplate text for `empty.md`

### DIFF
--- a/docs/empty.md
+++ b/docs/empty.md
@@ -1,0 +1,3 @@
+Sorry, there is currently no content here!! 
+
+Want to help us add it? Pull requests are gladly acccepted at https://github.com/hdzerowiki/wiki

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,8 +21,8 @@ nav:
   - Products: products.md
   - Troubleshooting:
           - Common Problems:
-            - Bricked VTX: updating_vtx/updating_hdzero_whoop.md
-            - Bricked VRX: updating_vtx/updating_hdzero_whoop.md
+            - Bricked VTX: empty.md
+            - Bricked VRX: empty.md
   
 extra_css:
   - stylesheets/extra.css


### PR DESCRIPTION
So the mkdocs wiki doesn't keep breaking